### PR TITLE
Фича: передача параметров при открытии сервиса с хэшем

### DIFF
--- a/src/hooks/useStructure.ts
+++ b/src/hooks/useStructure.ts
@@ -23,7 +23,15 @@ export function useStructure<S extends ApplicationStructure, T>(
     navigator.unfreezeLifecycle()
 
     if (hash) {
-      router.push(navigator.convertSearchParams(hash))
+      let original = navigator.convertSearchParams(hash)
+      let params = { ...original }
+
+      // Удаляем из параметров данные о структуре приложения
+      delete params.panel
+      delete params.view
+      delete params.story
+
+      router.push(original, params)
     }
   }, [])
 


### PR DESCRIPTION
Теперь можно передавать параметры (доступны через хук `useParams`) ссылкой.

Пример:
vk.com/app000#panel=info&name=Anton – при переходе по этой ссылке произойдет переход на панель `info`, а объект, полученный с помощью хука `useParams` будет равен `{ name: 'Anton' }`.